### PR TITLE
Check for helm version and choose plugin verification based on it

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -24,6 +24,7 @@ jobs:
       uses: azure/setup-helm@v4.3.1
       with:
         version: ${{ inputs.helm-version }}
+        check-latest: true
     - run: |
         set -e
         PLUGIN_NAME="unittest"

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -31,13 +31,16 @@ jobs:
         PLUGIN_URL="https://github.com/helm-unittest/helm-unittest.git"
         INSTALLED_VERSION=$(helm plugin list | awk -v name="$PLUGIN_NAME" '$1 == name {print $2}')
         MAJOR_VERSION=$(helm version --short | grep -Eo 'v[0-9]+' | cut -d'v' -f2)
-        if helm plugin list | grep -q "$PLUGIN_NAME" && [ "$INSTALLED_VERSION" != "$DESIRED_VERSION" ]; then
+        MAJOR_VERSION=${MAJOR_VERSION:-3}
+        if ! helm plugin list | grep -q "$PLUGIN_NAME" || [ "$INSTALLED_VERSION" != "$DESIRED_VERSION" ]; then
+          if helm plugin list | grep -q "$PLUGIN_NAME"; then
             helm plugin uninstall "$PLUGIN_NAME"
-        fi
-        if [ "$MAJOR_VERSION" -ge 4 ]; then
-          helm plugin install --verify=false --version "$DESIRED_VERSION" "$PLUGIN_URL"
-        else
-          helm plugin install --version "$DESIRED_VERSION" "$PLUGIN_URL"
+          fi
+          if [ "$MAJOR_VERSION" -ge 4 ]; then
+            helm plugin install --verify=false --version "$DESIRED_VERSION" "$PLUGIN_URL"
+          else
+            helm plugin install --version "$DESIRED_VERSION" "$PLUGIN_URL"
+          fi
         fi
     - run: helm dependency update
     - run: helm unittest -t JUnit -o test-output.xml . 

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -24,20 +24,20 @@ jobs:
       uses: azure/setup-helm@v4.3.1
       with:
         version: ${{ inputs.helm-version }}
-        check-latest: true
     - run: |
         set -e
         PLUGIN_NAME="unittest"
         DESIRED_VERSION="${{ inputs.helm-unittest-version }}"
         PLUGIN_URL="https://github.com/helm-unittest/helm-unittest.git"
         INSTALLED_VERSION=$(helm plugin list | awk -v name="$PLUGIN_NAME" '$1 == name {print $2}')
-        if helm plugin list | grep -q "$PLUGIN_NAME"; then
-          if [ "$INSTALLED_VERSION" != "$DESIRED_VERSION" ]; then
+        MAJOR_VERSION=$(helm version --short | grep -Eo 'v[0-9]+' | cut -d'v' -f2)
+        if helm plugin list | grep -q "$PLUGIN_NAME" && [ "$INSTALLED_VERSION" != "$DESIRED_VERSION" ]; then
             helm plugin uninstall "$PLUGIN_NAME"
-            helm plugin install --verify=false --version "$DESIRED_VERSION" "$PLUGIN_URL"
-          fi
-        else
+        fi
+        if [ "$MAJOR_VERSION" -ge 4 ]; then
           helm plugin install --verify=false --version "$DESIRED_VERSION" "$PLUGIN_URL"
+        else
+          helm plugin install --version "$DESIRED_VERSION" "$PLUGIN_URL"
         fi
     - run: helm dependency update
     - run: helm unittest -t JUnit -o test-output.xml . 


### PR DESCRIPTION
In helm version 4 a `--verify` flag was added. This lead to errors in the helm unittest workflow, since helm version 3 does not have a `--verify` flag. This pull request adds a check to the version and only uses the `--verify` flag if the version is compatible.