### PR TITLE
Fix missing crds and subcharts in hydration folder

### DIFF
--- a/.github/workflows/helm-hydration.yaml
+++ b/.github/workflows/helm-hydration.yaml
@@ -85,7 +85,7 @@ jobs:
           .
           mkdir -p "$HYDRATED_MANIFESTS"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
-          mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" | true
+          mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" || true
     - name: Create pull request
       if: ${{ !env.ACT }}
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/helm-hydration.yaml
+++ b/.github/workflows/helm-hydration.yaml
@@ -85,6 +85,7 @@ jobs:
           .
           mkdir -p "$HYDRATED_MANIFESTS"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
+          mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/" dir/ 2>/dev/null
     - name: Create pull request
       if: ${{ !env.ACT }}
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/helm-hydration.yaml
+++ b/.github/workflows/helm-hydration.yaml
@@ -85,7 +85,7 @@ jobs:
           .
           mkdir -p "$HYDRATED_MANIFESTS"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
-          mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/" dir/ 2>/dev/null
+          mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" | true
     - name: Create pull request
       if: ${{ !env.ACT }}
       uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
This pull request makes a minor update to the Helm hydration workflow by adding a command to move chart files from a temporary directory to a new location, handling the case where the source directory may not exist.

- Workflow improvement:
  * [`.github/workflows/helm-hydration.yaml`](diffhunk://#diff-f40e3b76e625d1dc3d17c636af47e3925b6fd671cdb52c5acab4eab7b3e476daR88): Added a step to move files from the `charts` directory to a new `chartz` directory within the hydrated manifests, using `|| true` to avoid errors if the source directory is missing.