### PR TITLE
Helm hydration patch crd annotations

### DIFF
--- a/.github/workflows/helm-hydration.yaml
+++ b/.github/workflows/helm-hydration.yaml
@@ -83,6 +83,17 @@ jobs:
           --release-name $RELEASE_NAME \
           --skip-tests \
           .
+          find "${{ runner.temp }}/$HYDRATED_MANIFESTS" -type f \( -name "*.yaml" -o -name "*.yml" \) -exec yq -i '
+            select(.kind == "CustomResourceDefinition" and
+              .metadata.annotations["argocd.argoproj.io/sync-options"] == null)
+              .metadata.annotations["argocd.argoproj.io/sync-options"] = "ServerSideApply=true" |
+            select(.kind == "CustomResourceDefinition" and .metadata.annotations["argocd.argoproj.io/sync-options"] != null and
+              (.metadata.annotations["argocd.argoproj.io/sync-options"] |
+              contains("ServerSideApply=") | not))
+              .metadata.annotations["argocd.argoproj.io/sync-options"] |= . + ",ServerSideApply=true" |
+            select(.kind == "CustomResourceDefinition" and .metadata.annotations["argocd.argoproj.io/sync-wave"] == null)
+              .metadata.annotations["argocd.argoproj.io/sync-wave"] = "-1"
+          ' {} \;
           mkdir -p "$HYDRATED_MANIFESTS"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" || true

--- a/.github/workflows/helm-hydration.yaml
+++ b/.github/workflows/helm-hydration.yaml
@@ -97,6 +97,8 @@ jobs:
           mkdir -p "$HYDRATED_MANIFESTS"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" || true
+    - name: Print all files
+      run: find hydrated-manifests -type f -exec cat {} \;
     - name: Create pull request
       if: ${{ !env.ACT }}
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/helm-hydration.yaml
+++ b/.github/workflows/helm-hydration.yaml
@@ -97,8 +97,6 @@ jobs:
           mkdir -p "$HYDRATED_MANIFESTS"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
           mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" || true
-    - name: Print all files
-      run: find hydrated-manifests -type f -exec cat {} \;
     - name: Create pull request
       if: ${{ !env.ACT }}
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/helm-hydration.yaml
+++ b/.github/workflows/helm-hydration.yaml
@@ -83,20 +83,22 @@ jobs:
           --release-name $RELEASE_NAME \
           --skip-tests \
           .
-          find "${{ runner.temp }}/$HYDRATED_MANIFESTS" -type f \( -name "*.yaml" -o -name "*.yml" \) -exec yq -i '
-            select(.kind == "CustomResourceDefinition" and
-              .metadata.annotations["argocd.argoproj.io/sync-options"] == null)
-              .metadata.annotations["argocd.argoproj.io/sync-options"] = "ServerSideApply=true" |
-            select(.kind == "CustomResourceDefinition" and .metadata.annotations["argocd.argoproj.io/sync-options"] != null and
-              (.metadata.annotations["argocd.argoproj.io/sync-options"] |
-              contains("ServerSideApply=") | not))
-              .metadata.annotations["argocd.argoproj.io/sync-options"] |= . + ",ServerSideApply=true" |
-            select(.kind == "CustomResourceDefinition" and .metadata.annotations["argocd.argoproj.io/sync-wave"] == null)
-              .metadata.annotations["argocd.argoproj.io/sync-wave"] = "-1"
-          ' {} \;
-          mkdir -p "$HYDRATED_MANIFESTS"
-          mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
-          mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" || true
+        # Add ServerSideApply=true to sync-options if ServerSideApply is not defined
+        # Set sync-wave to -1 if sync-wave is not defined
+        find "${{ runner.temp }}/$HYDRATED_MANIFESTS" -type f \( -name "*.yaml" -o -name "*.yml" \) -exec yq -i '
+          select(.kind == "CustomResourceDefinition" and
+            .metadata.annotations["argocd.argoproj.io/sync-options"] == null)
+            .metadata.annotations["argocd.argoproj.io/sync-options"] = "ServerSideApply=true" |
+          select(.kind == "CustomResourceDefinition" and .metadata.annotations["argocd.argoproj.io/sync-options"] != null and
+            (.metadata.annotations["argocd.argoproj.io/sync-options"] |
+            contains("ServerSideApply=") | not))
+            .metadata.annotations["argocd.argoproj.io/sync-options"] |= . + ",ServerSideApply=true" |
+          select(.kind == "CustomResourceDefinition" and .metadata.annotations["argocd.argoproj.io/sync-wave"] == null)
+            .metadata.annotations["argocd.argoproj.io/sync-wave"] = "-1"
+        ' {} \;
+        mkdir -p "$HYDRATED_MANIFESTS"
+        mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/$CHART_NAME"/* "$HYDRATED_MANIFESTS/"
+        mv -v "${{ runner.temp }}/$HYDRATED_MANIFESTS/$RELEASE_NAME/charts"/* "$HYDRATED_MANIFESTS/chartz" || true
     - name: Create pull request
       if: ${{ !env.ACT }}
       uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
This pull request updates the Helm hydration workflow to ensure that all generated CustomResourceDefinition (CRD) manifests have the necessary ArgoCD annotations for sync options and sync wave. The main change is the addition of a `yq` command that modifies CRD YAML files to standardize these annotations.
